### PR TITLE
Androidの課金に必要な権限を宣言した

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,6 +20,6 @@
     <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
     <meta-data android:name="flutterEmbedding" android:value="2"/>
-    <uses-permission android:name="com.android.vending.BILLING" />
   </application>
+  <uses-permission android:name="com.android.vending.BILLING" />
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,5 +20,6 @@
     <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
     <meta-data android:name="flutterEmbedding" android:value="2"/>
+    <uses-permission android:name="com.android.vending.BILLING" />
   </application>
 </manifest>


### PR DESCRIPTION
## Abstract
ref: https://support.google.com/googleplay/android-developer/answer/1153481?hl=ja
> アプリ内アイテムを提供するには、アプリの APK マニフェスト ファイルで com.android.vending.BILLING 権限を宣言する必要があります。アプリをグローバルに配信する場合、すべての国で com.android.vending.BILLING 権限を指定して、アプリを公開できます。