### PR TITLE
rename purchase items

### DIFF
--- a/lib/features/home/home.dart
+++ b/lib/features/home/home.dart
@@ -21,7 +21,6 @@ class AppHome extends HookConsumerWidget {
     useEffect(() {
       final userID = state.asData?.value.user.id;
       if (userID != null) {
-        debugPrint("userID: $userID");
         unawaited(FirebaseAnalytics.instance.setUserId(id: userID));
         unawaited(FirebaseCrashlytics.instance.setUserIdentifier(userID));
       }

--- a/lib/features/home/state.codegen.dart
+++ b/lib/features/home/state.codegen.dart
@@ -11,7 +11,7 @@ final homeAsyncStateProvider =
   try {
     final goals = ref.watch(goalsStreamProvider);
 
-    if (user is AsyncLoading || goals is AsyncLoading) {
+    if (goals is AsyncLoading) {
       return const AsyncValue.loading();
     }
 

--- a/lib/provider/purchase.dart
+++ b/lib/provider/purchase.dart
@@ -35,6 +35,7 @@ List<String> productIdentifiers() {
 }
 
 final purchaseProductsProvider = FutureProvider((ref) async {
-  final products = await Purchases.getProducts(productIdentifiers());
+  final products = await Purchases.getProducts(productIdentifiers(),
+      type: PurchaseType.inapp);
   return products..sort((a, b) => a.price > b.price ? 1 : 0);
 });

--- a/lib/provider/purchase.dart
+++ b/lib/provider/purchase.dart
@@ -1,16 +1,28 @@
+import 'dart:io';
+
 import 'package:in_100_days/flavors.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
 import 'package:riverpod/riverpod.dart';
 
 List<String> productIdentifiers() {
   if (F.appFlavor == Flavor.DEV) {
-    return [
-      "in100days_dev_120_consume",
-      "in100days_dev_370_consume",
-      "in100days_dev_730_consume",
-      "in100days_dev_1220_consume",
-      "in100days_dev_12000_consume",
-    ];
+    if (Platform.isIOS) {
+      return [
+        "in100days_dev_120_consume",
+        "in100days_dev_370_consume",
+        "in100days_dev_730_consume",
+        "in100days_dev_1220_consume",
+        "in100days_dev_12000_consume",
+      ];
+    } else {
+      return [
+        "in100days_dev2_120_consume",
+        "in100days_dev2_370_consume",
+        "in100days_dev2_730_consume",
+        "in100days_dev2_1220_consume",
+        "in100days_dev2_12000_consume",
+      ];
+    }
   } else {
     return [
       "in100days_120_consume",

--- a/lib/provider/user.dart
+++ b/lib/provider/user.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:in_100_days/provider/auth.dart';
 
@@ -38,6 +39,7 @@ final userStreamProvider = StreamProvider<User?>((ref) {
     return Stream.value(null);
   }
 
+  debugPrint("userID: ${firebaseCurrentUserValue.uid}");
   return userDocumentReference(userID: firebaseCurrentUserValue.uid)
       .snapshots()
       .map((event) => event.data());

--- a/lib/provider/user.dart
+++ b/lib/provider/user.dart
@@ -33,12 +33,12 @@ final userStreamProvider = StreamProvider<User?>((ref) {
     return const Stream.empty();
   }
 
-  final twitterAuthTokenSecretValue = firebaseCurrentUser.asData?.value;
-  if (twitterAuthTokenSecretValue == null) {
+  final firebaseCurrentUserValue = firebaseCurrentUser.asData?.value;
+  if (firebaseCurrentUserValue == null) {
     return Stream.value(null);
   }
 
-  return userDocumentReference(userID: twitterAuthTokenSecretValue.uid)
+  return userDocumentReference(userID: firebaseCurrentUserValue.uid)
       .snapshots()
       .map((event) => event.data());
 });


### PR DESCRIPTION
Androidの方で課金プロダクトが表示されなくて変更を加えた
- Play Store,RevenueCatのプロダクトを作り直した。同じproduct identifierは使えないので違うIDで作った。結局これは意味がなかった
- Purchasesライブラリのメソッドで `PurchaseType.inapp` を指定できる場所は指定する。Androidの場合はsubとinappが明確に分かれている模様
  - ref: https://github.com/RevenueCat/purchases-flutter/issues/320